### PR TITLE
Update setup-java action to v2

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Updating the [setup-java](https://github.com/actions/setup-java) action to v2. 

- V2 supports custom distributions and provides support for `Zulu OpenJDK`, `Eclipse` `Temurin` and `Adopt OpenJDK`. V1 supports only `Zulu OpenJDK`.
- V1 supported legacy Java syntax such as 1.8 (same as 8) and 1.8.0.212 (same as 8.0.212). V2 dropped support for legacy syntax.