### PR TITLE
[UPDATE] - Robolectric Version Update

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,7 +21,7 @@ object Dependencies {
   const val AppCompat = "androidx.appcompat:appcompat:1.2.0"
   const val JUnit = "junit:junit:4.13"
   const val Mockito = "org.mockito:mockito-core:3.4.6"
-  const val Robolectric = "org.robolectric:robolectric:4.3.1"
+  const val Robolectric = "org.robolectric:robolectric:4.6.1"
   const val Truth = "com.google.truth:truth:1.1.3"
 
   object InstrumentationTests {


### PR DESCRIPTION
This is a minor release, in which ShadowActivityManager contained a reference to android.app.ApplicationExitInfo, introduced in SDK 30, in public method. This caused shadowOf to fail if the target SDK was < 30.