### PR TITLE
Make the API more java-friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ are evaluated.
 override any app specific set up.
 * Changed the `minPriority` default parameter value of
 `AndroidLogcatLogger.installOnDebuggableApp()` from `DEBUG` to `VERBOSE`.
-
+* Added `@JvmStatic` and removed `Kt` from class name (`LogcatKt` => `Logcat`) so that APIs are more Java friendly (this remains primarily a Kotlin focused APIs but this change helps with codebases that still have some Java code hanging around).
 
 
 Version 0.1

--- a/logcat/api/logcat.api
+++ b/logcat/api/logcat.api
@@ -3,6 +3,7 @@ public final class logcat/AndroidLogcatLogger : logcat/LogcatLogger {
 	public fun <init> ()V
 	public fun <init> (Llogcat/LogPriority;)V
 	public synthetic fun <init> (Llogcat/LogPriority;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun installOnDebuggableApp (Landroid/app/Application;Llogcat/LogPriority;)V
 	public fun isLoggable (Llogcat/LogPriority;)Z
 	public fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
 }
@@ -28,7 +29,7 @@ public final class logcat/LogPriority : java/lang/Enum {
 	public static fun values ()[Llogcat/LogPriority;
 }
 
-public final class logcat/LogcatKt {
+public final class logcat/Logcat {
 	public static final fun logcat (Ljava/lang/Object;Llogcat/LogPriority;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun logcat (Ljava/lang/String;Llogcat/LogPriority;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun logcat$default (Ljava/lang/Object;Llogcat/LogPriority;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
@@ -38,8 +39,12 @@ public final class logcat/LogcatKt {
 
 public abstract interface class logcat/LogcatLogger {
 	public static final field Companion Llogcat/LogcatLogger$Companion;
+	public static fun getLoggers ()Ljava/util/List;
+	public static fun install (Ljava/util/concurrent/Executor;)V
+	public static fun isInstalled ()Z
 	public abstract fun isLoggable (Llogcat/LogPriority;)Z
 	public abstract fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun uninstall ()V
 }
 
 public final class logcat/LogcatLogger$Companion {

--- a/logcat/src/main/java/logcat/AndroidLogcatLogger.kt
+++ b/logcat/src/main/java/logcat/AndroidLogcatLogger.kt
@@ -76,6 +76,7 @@ class AndroidLogcatLogger(minPriority: LogPriority = DEBUG) : LogcatLogger {
   }
 
   companion object {
+    @JvmStatic
     fun installOnDebuggableApp(application: Application, minPriority: LogPriority = VERBOSE) {
       if (!LogcatLogger.isInstalled && application.isDebuggableApp) {
         LogcatLogger.install()

--- a/logcat/src/main/java/logcat/Logcat.kt
+++ b/logcat/src/main/java/logcat/Logcat.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE")
+@file:JvmName("Logcat")
 
 package logcat
 

--- a/logcat/src/main/java/logcat/LogcatLogger.kt
+++ b/logcat/src/main/java/logcat/LogcatLogger.kt
@@ -29,6 +29,7 @@ interface LogcatLogger {
   )
 
   companion object {
+    @JvmStatic
     val loggers: MutableList<LogcatLogger> = CopyOnWriteArrayList()
 
     @Volatile
@@ -41,6 +42,7 @@ interface LogcatLogger {
 
     private val installLock = Any()
 
+    @JvmStatic
     val isInstalled: Boolean
       get() = installedThrowable != null
 
@@ -56,6 +58,7 @@ interface LogcatLogger {
      * It is an error to call [install] more than once without calling [uninstall] in between,
      * however doing this won't throw, it'll log an error to the newly provided logger.
      */
+    @JvmStatic
     fun install(logExecutor: Executor = Executor { it.run() }) {
       synchronized(installLock) {
         if (isInstalled) {
@@ -72,6 +75,7 @@ interface LogcatLogger {
     /**
      * Disables logging.
      */
+    @JvmStatic
     fun uninstall() {
       synchronized(installLock) {
         installedThrowable = null


### PR DESCRIPTION
* Get rid of ugly `*Kt` classnames in java
* Make APIs @JvmStatic so you don't have to use the companion object from java source