### PR TITLE
Lower kotlin version to 2.1.21 for metadata compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.0"
+kotlin = "2.1.21"
 androidGradlePlugin = "8.11.1"
 mavenPublish = "0.25.3"
 ktlint = "13.0.0"

--- a/logcat/api/android/logcat.api
+++ b/logcat/api/android/logcat.api
@@ -42,7 +42,7 @@ public abstract interface class logcat/LogcatLogger {
 	public static fun getLoggers ()Ljava/util/List;
 	public static fun install ()V
 	public static fun isInstalled ()Z
-	public fun isLoggable (Llogcat/LogPriority;)Z
+	public abstract fun isLoggable (Llogcat/LogPriority;)Z
 	public abstract fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun uninstall ()V
 }

--- a/logcat/api/jvm/logcat.api
+++ b/logcat/api/jvm/logcat.api
@@ -27,7 +27,7 @@ public abstract interface class logcat/LogcatLogger {
 	public static fun getLoggers ()Ljava/util/List;
 	public static fun install ()V
 	public static fun isInstalled ()Z
-	public fun isLoggable (Llogcat/LogPriority;)Z
+	public abstract fun isLoggable (Llogcat/LogPriority;)Z
 	public abstract fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun uninstall ()V
 }


### PR DESCRIPTION
Testing local snapshots with register using kotlin 2.2.0 was causing kotlin metadata errors: 
```
e: Incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
e: file:///Users/japplin/.gradle/caches/8.12.1/transforms/cd21354a9c7364ee1e7df11c6250f1b7/transformed/logcat-release-api.jar!/META-INF/logcat_release.kotlin_module Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.2.0, expected version is 2.0.0.
```
Lowering to 2.1.21 which is compatible.