### PR TITLE
Use Timber-like API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ hs_err_pid*
 # Gradle
 out/
 .gradle/
+.kotlin/
 build/
 local.properties
 .gradletasknamecache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,14 @@
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.binary.compatibility.validator) apply false
+  alias(libs.plugins.dokka) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.maven.publish) apply false
   alias(libs.plugins.ktlint)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.21"
+kotlin = "2.2.0"
 androidGradlePlugin = "8.11.1"
 mavenPublish = "0.25.3"
 ktlint = "13.0.0"

--- a/logcat/api/android/logcat.api
+++ b/logcat/api/android/logcat.api
@@ -72,8 +72,6 @@ public final class logcat/ThrowablesKt {
 
 public final class logcat/logcat {
 	public static final field INSTANCE Llogcat/logcat;
-	public final fun assert (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun assert$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun d (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun d$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun e (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
@@ -84,5 +82,7 @@ public final class logcat/logcat {
 	public static synthetic fun v$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun w (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun w$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun wtf (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun wtf$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 

--- a/logcat/api/android/logcat.api
+++ b/logcat/api/android/logcat.api
@@ -70,3 +70,19 @@ public final class logcat/ThrowablesKt {
 	public static final fun asLog (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public final class logcat/logcat {
+	public static final field INSTANCE Llogcat/logcat;
+	public final fun assert (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun assert$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun d (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun d$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun e (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun i (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun i$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun v (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun v$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun w (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun w$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+

--- a/logcat/api/android/logcat.api
+++ b/logcat/api/android/logcat.api
@@ -42,7 +42,7 @@ public abstract interface class logcat/LogcatLogger {
 	public static fun getLoggers ()Ljava/util/List;
 	public static fun install ()V
 	public static fun isInstalled ()Z
-	public abstract fun isLoggable (Llogcat/LogPriority;)Z
+	public fun isLoggable (Llogcat/LogPriority;)Z
 	public abstract fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun uninstall ()V
 }

--- a/logcat/api/jvm/logcat.api
+++ b/logcat/api/jvm/logcat.api
@@ -55,3 +55,19 @@ public final class logcat/ThrowablesKt {
 	public static final fun asLog (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public final class logcat/logcat {
+	public static final field INSTANCE Llogcat/logcat;
+	public final fun assert (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun assert$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun d (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun d$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun e (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun i (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun i$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun v (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun v$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun w (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun w$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+

--- a/logcat/api/jvm/logcat.api
+++ b/logcat/api/jvm/logcat.api
@@ -57,8 +57,6 @@ public final class logcat/ThrowablesKt {
 
 public final class logcat/logcat {
 	public static final field INSTANCE Llogcat/logcat;
-	public final fun assert (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun assert$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun d (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun d$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun e (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
@@ -69,5 +67,7 @@ public final class logcat/logcat {
 	public static synthetic fun v$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun w (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun w$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun wtf (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun wtf$default (Llogcat/logcat;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 

--- a/logcat/api/jvm/logcat.api
+++ b/logcat/api/jvm/logcat.api
@@ -27,7 +27,7 @@ public abstract interface class logcat/LogcatLogger {
 	public static fun getLoggers ()Ljava/util/List;
 	public static fun install ()V
 	public static fun isInstalled ()Z
-	public abstract fun isLoggable (Llogcat/LogPriority;)Z
+	public fun isLoggable (Llogcat/LogPriority;)Z
 	public abstract fun log (Llogcat/LogPriority;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun uninstall ()V
 }

--- a/logcat/build.gradle.kts
+++ b/logcat/build.gradle.kts
@@ -26,20 +26,24 @@ kotlin {
     }
   }
 
+  compilerOptions {
+    freeCompilerArgs.add("-Xcontext-parameters")
+  }
+
   sourceSets {
     val commonMain by getting {
       dependencies {
         implementation(libs.kotlin.stdlib)
       }
     }
-    
+
     val commonTest by getting {
       dependencies {
         implementation(libs.kotlin.test)
         implementation(libs.truthish)
       }
     }
-    
+
     val androidMain by getting
     val jvmMain by getting
   }

--- a/logcat/src/commonMain/kotlin/logcat/Logcat.kt
+++ b/logcat/src/commonMain/kotlin/logcat/Logcat.kt
@@ -154,7 +154,7 @@ object logcat {
   ) = subject.logcat(LogPriority.ERROR, tag, message)
 
   context(subject: Any)
-  fun assert(
+  fun wtf(
     tag: String? = null,
     message: () -> String
   ) = subject.logcat(LogPriority.ASSERT, tag, message)

--- a/logcat/src/commonMain/kotlin/logcat/Logcat.kt
+++ b/logcat/src/commonMain/kotlin/logcat/Logcat.kt
@@ -91,3 +91,71 @@ inline fun logcat(
     }
   }
 }
+
+/**
+ * An alternative way of calling the free [logcat] method using a Timber-like API.
+ *
+ * Use like:
+ *
+ * ```kotlin
+ * import logcat.logcat
+ *
+ * class MouseController {
+ *
+ *   fun play {
+ *     var state = "CHEEZBURGER"
+ *     logcat.d { "I CAN HAZ $state?" }
+ *     // logcat output: D/MouseController: I CAN HAZ CHEEZBURGER?
+ *
+ *     logcat.i { "DID U ASK 4 MOAR INFO?" }
+ *     // logcat output: I/MouseController: DID U ASK 4 MOAR INFO?
+ *
+ *     logcat.w { exception.asLog() }
+ *     // logcat output: W/MouseController: java.lang.RuntimeException: FYLEZ KERUPTED
+ *     //                        at sample.MouseController.play(MouseController.kt:22)
+ *     //                        ...
+ *
+ *     logcat.e("Lolcat") { "OH HI" }
+ *     // logcat output: E/Lolcat: OH HI
+ *   }
+ * }
+ * ```
+ */
+@Suppress("ClassName")
+object logcat {
+  context(subject: Any)
+  fun v(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(LogPriority.VERBOSE, tag, message)
+
+  context(subject: Any)
+  fun d(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(DEBUG, tag, message)
+
+  context(subject: Any)
+  fun i(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(LogPriority.INFO, tag, message)
+
+  context(subject: Any)
+  fun w(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(LogPriority.WARN, tag, message)
+
+  context(subject: Any)
+  fun e(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(LogPriority.ERROR, tag, message)
+
+  context(subject: Any)
+  fun assert(
+    tag: String? = null,
+    message: () -> String
+  ) = subject.logcat(LogPriority.ASSERT, tag, message)
+}

--- a/logcat/src/commonTest/kotlin/logcat/LogcatShortcutsTest.kt
+++ b/logcat/src/commonTest/kotlin/logcat/LogcatShortcutsTest.kt
@@ -1,0 +1,72 @@
+package logcat
+
+import logcat.LogPriority.ASSERT
+import logcat.LogPriority.DEBUG
+import logcat.LogPriority.ERROR
+import logcat.LogPriority.INFO
+import logcat.LogPriority.VERBOSE
+import logcat.LogPriority.WARN
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class LogcatObjectTest {
+  private lateinit var logger: TestLogcatLogger
+
+  @BeforeTest
+  fun before() {
+    LogcatLogger.install()
+    logger = TestLogcatLogger()
+    LogcatLogger.loggers += logger
+  }
+
+  @AfterTest
+  fun after() {
+    LogcatLogger.uninstall()
+    LogcatLogger.loggers -= logger
+  }
+
+  // don't add another test above this - it depends on the line number
+  @Test
+  fun `Log exception`() {
+    val e = IllegalStateException("SOMETHING BROKE")
+    logcat.e { e.asLog() }
+    val log = logger.latestLog
+    assertEquals(expected = ERROR, log?.priority)
+    assertEquals(expected = "LogcatObjectTest", log?.tag)
+    val msg = log?.message.orEmpty()
+    assertContains(msg, "java.lang.IllegalStateException: SOMETHING BROKE")
+    assertContains(msg, "at logcat.LogcatObjectTest.Log exception(LogcatShortcutsTest.kt:34)")
+  }
+
+  @Test
+  fun `Logcat shortcuts`() {
+    logcat.v { "verbose" }
+    logger.assertLatest(priority = VERBOSE, tag = "LogcatObjectTest", message = "verbose")
+
+    logcat.d("DebugTag") { "debug" }
+    logger.assertLatest(priority = DEBUG, tag = "DebugTag", message = "debug")
+
+    logcat.i { "info" }
+    logger.assertLatest(priority = INFO, tag = "LogcatObjectTest", message = "info")
+
+    logcat.w(tag = null) { "warning" }
+    logger.assertLatest(priority = WARN, tag = "LogcatObjectTest", message = "warning")
+
+    logcat.assert { "assert" }
+    logger.assertLatest(priority = ASSERT, tag = "LogcatObjectTest", message = "assert")
+  }
+
+  @Test
+  fun `Grab tag from the wrapper class inside apply block`() {
+    val myString = "abc-123"
+
+    myString.apply {
+      logcat.i { "my log message" }
+    }
+
+    logger.assertLatest(priority = INFO, tag = "String", message = "my log message")
+  }
+}

--- a/logcat/src/commonTest/kotlin/logcat/LogcatShortcutsTest.kt
+++ b/logcat/src/commonTest/kotlin/logcat/LogcatShortcutsTest.kt
@@ -55,8 +55,8 @@ class LogcatObjectTest {
     logcat.w(tag = null) { "warning" }
     logger.assertLatest(priority = WARN, tag = "LogcatObjectTest", message = "warning")
 
-    logcat.assert { "assert" }
-    logger.assertLatest(priority = ASSERT, tag = "LogcatObjectTest", message = "assert")
+    logcat.wtf { "PANIC" }
+    logger.assertLatest(priority = ASSERT, tag = "LogcatObjectTest", message = "PANIC")
   }
 
   @Test

--- a/logcat/src/commonTest/kotlin/logcat/TestLogcatLogger.kt
+++ b/logcat/src/commonTest/kotlin/logcat/TestLogcatLogger.kt
@@ -1,5 +1,7 @@
 package logcat
 
+import kotlin.test.assertEquals
+
 class TestLogcatLogger : LogcatLogger {
   override fun isLoggable(priority: LogPriority): Boolean {
     latestPriority = priority
@@ -23,4 +25,13 @@ class TestLogcatLogger : LogcatLogger {
   ) {
     latestLog = Log(priority, tag, message)
   }
+
+  fun assertLatest(
+    priority: LogPriority,
+    tag: String,
+    message: String
+  ) = assertEquals(
+    expected = Log(priority, tag, message),
+    actual = latestLog
+  )
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.android)
@@ -11,8 +13,10 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 
-  kotlinOptions {
-    jvmTarget = "1.8"
+  kotlin {
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_1_8
+    }
   }
 
   defaultConfig {


### PR DESCRIPTION
This is more of a suggestion than a proper pull request - trying to see whether anyone else thinks it's a good idea. It's not adding any functionality, just a different interface, so it could just be split off into a separate module or something.

Basically just a wrapper around the existing `logcat` method, making use of context receivers (hence the 2.2.0 kotlin version bump) to more easily include the logging priority as part of the function call. Less of need for the developer to stop and press alt+enter all the time to import the logcat method and the LogPriority enum entry - arguably better DevX?

```kotlin
logcat { "here's a classic log call" }
logcat(INFO) { "here's another with explicit priority" }

logcat.i { "Behaves the same as above" }
logcat.w("MyTag") { "blah blah blah" }
logcat.wtf { "PANIC" }
```

Intentionally kept the new object with a lower-case name to match the existing method - but obviously there are other ways of doing this. Although like this, we can write code like above with just the one import statement of `import logcat.logcat`.

Thoughts?