### PR TITLE
Deprecate 'Any.outerClassSimpleNameInternalOnlyDoNotUseKThxBye'

### DIFF
--- a/logcat/src/androidMain/kotlin/logcat/BackwardCompatLogcat.kt
+++ b/logcat/src/androidMain/kotlin/logcat/BackwardCompatLogcat.kt
@@ -7,6 +7,7 @@ import kotlin.jvm.JvmName
 import logcat.internal.outerClassSimpleName
 
 // Kept here for backward compat purposes
+@Deprecated("This is an internal logcat API that should not be used from outside of logcat.")
 @OptIn(InternalLogcatApi::class)
 @Suppress("unused")
 @PublishedApi


### PR DESCRIPTION
It's only there for binary compatibility anyway